### PR TITLE
Fix skip fuction to ignore comments

### DIFF
--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -2252,7 +2252,7 @@ fn skip(code: &str) -> &str {
       }
       continue;
     }
-    if head(code) == '/' {
+    if head(code) == '/' && head(tail(code)) == '/' {
       while head(code) != '\n' && head(code) != '\0' {
         code = tail(code);
       }


### PR DESCRIPTION
Fix the parsing error when use the operator `/` like `(/ #10 #2)` 