### PR TITLE
Heap serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/~*
+~*
 /.vscode/launch.json
 /.vscode/tasks.json
 
 /target/
+
+*.bin

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod bits;
 
 use primitive_types::U256;
 
+use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -19,7 +20,6 @@ use std::thread;
 pub use clap::{Parser, Subcommand};
 
 use crate::bits::*;
-use crate::hvm::*;
 use crate::node::*;
 use crate::util::*;
 
@@ -28,12 +28,8 @@ const KINDELIA_HOME_DEFAULT: &str = ".kindelia";
 
 fn main() -> Result<(), String> {
   return run_cli();
-
-  //start_node(Some("simple.kindelia".to_string()));
-  //return Ok(());
-  
-  //hvm::test("./example/example.kindelia");
-  //return Ok(());
+  // test_from_file("./example/example.kindelia");
+  // return Ok(());
 }
 
 #[derive(Parser)]
@@ -57,6 +53,8 @@ pub enum CliCmd {
     file: String,
     // #[clap(short, long)]
     // debug: bool,
+    #[clap(long)]
+    save_heap: bool,
   },
 }
 
@@ -70,18 +68,55 @@ fn run_cli() -> Result<(), String> {
       eprintln!("Starting node on directory: {:?}", base_dir);
       start_node(base_dir, file);
     }
-    CliCmd::Run { file } => {
+    CliCmd::Run { file, save_heap } => {
       let file = std::fs::read_to_string(file);
       match file {
         Err(err) => return Err(format!("{}", err)),
         Ok(code) => {
+          let heap_file = if save_heap {
+            let heap_file = fs::File::create("./run.heap.bin").map_err(|e| e.to_string())?;
+            Some(heap_file)
+          } else {
+            None
+          };
           // TODO: flag to disable size limit / debug
-          hvm::test_statements_from_code(&code);
+          run_code(&code, heap_file)?;
         }
       }
     }
   };
   Ok(())
+}
+
+fn run_code(code: &str, heap_file: Option<fs::File>) -> Result<(), String> {
+  let stmts = &hvm::read_statements(code).1;
+  let rt = run_statements(stmts);
+  if let Some(mut heap_file) = heap_file {
+    eprint!("Writing heap to file... ");
+    rt.get_heap(rt.curr).serialize(&mut heap_file)?;
+    eprintln!("Done.");
+  }
+  Ok(())
+}
+
+// Serializes, deserializes and evaluates statements
+fn run_statements(statements: &[hvm::Statement]) -> hvm::Runtime {
+  let str_0 = hvm::view_statements(statements);
+  let str_1 = hvm::view_statements(&crate::bits::deserialized_statements(&crate::bits::serialized_statements(&statements)));
+  if str_0 != str_1 { eprintln!("ERROR: SERIALIZATION ERROR, PLEASE REPORT") };
+
+  eprintln!("[Evaluation]");
+  let mut rt = hvm::init_runtime();
+  let init = std::time::Instant::now();
+  rt.run_statements(&statements);
+  let elapsed = init.elapsed();
+
+  eprintln!();
+  eprintln!("[Stats]");
+  eprintln!("- cost: {} mana ({} rewrites)", rt.get_mana(), rt.get_rwts());
+  eprintln!("- size: {} words", rt.get_size());
+  eprintln!("- time: {} ms", elapsed.as_millis());
+  rt
 }
 
 fn start_node(base_dir: PathBuf, file: Option<String>) {
@@ -142,4 +177,16 @@ fn get_base_dir(dir_cli: Option<String>) -> Result<PathBuf, String> {
     dir_cli.or(dir_env).map(|x| PathBuf::from(x)).unwrap_or(dir_home);
 
   Ok(base_dir)
+}
+
+// Tests
+// -----
+
+pub fn test_statements_from_code(code: &str) {
+  run_statements(&hvm::read_statements(code).1);
+}
+
+pub fn test_from_file(path: &str) {
+  let file = &std::fs::read_to_string(path).expect("file not found");
+  test_statements_from_code(file);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,6 +94,16 @@ pub trait Ser<T: Copy, E = String> {
 // Serialization Implementations
 // -----------------------------
 
+impl Sink<u128> for std::fs::File
+{
+  fn write_val(&mut self, val: u128) -> Result<(), String> {
+    use std::io::Write;
+    let bytes = val.to_le_bytes();
+    self.write_all(&bytes).map_err(|e| e.to_string())?;
+    Ok(())
+  }
+}
+
 impl <T: Copy> Sink<T> for Vec<T> {
   fn write_val(&mut self, val: T) -> Result<(), String> {
     self.push(val);

--- a/test/fold.kdl
+++ b/test/fold.kdl
@@ -1,0 +1,11 @@
+$(Nil)
+$(Cons x xs)
+
+!(Fold f i l) {
+  !(Fold ~ i $(Nil)) = i
+  !(Fold f i $(Cons x xs)) = &{f0 f1} = f; ((f0 x) !(Fold f1 i xs))
+} = #0
+
+{
+  $(IO.done !(Fold @x @y (+ x y) #0 $(Cons #2 $(Cons #1 $(Nil)))))
+}


### PR DESCRIPTION
This already adds a flag `--save-heap` to `kindelia run` to save the heap resulting from running the code to a file.

This will create a 67MB the file named `run.heap.bin`:
```
RUST_BACKTRACE=1 cargo run --profile=dev_fast -- run example/example.kindelia --save-heap
```