### PR TITLE
fix RTL and RTR in `show_term`

### DIFF
--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -2547,8 +2547,8 @@ pub fn show_term(rt: &Runtime, term: Lnk) -> String {
           UTUP_GTE => "~>=",
           UTUP_GTN => "~>",
           UTUP_NEQ => "~!=",
-          UTUP_RTL => "~>~",
-          UTUP_RTR => "~<~",
+          UTUP_RTL => "~<~",
+          UTUP_RTR => "~>~",
           _        => "?",
         };
         format!("({} {} {})", symb, val0, val1)


### PR DESCRIPTION
fixing typos in `show_term`