### PR TITLE
Fix hvm parsing of binary operators

### DIFF
--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -3938,7 +3938,6 @@ pub fn read_term(code: &str) -> ParseResult<Term> {
       let code = tail(code);
       let (code, oper) = read_oper(code);
       if let Some(oper) = oper {
-        let code = tail(code);
         let (code, val0) = read_term(code)?;
         let (code, val1) = read_term(code)?;
         let (code, unit) = read_char(code, ')')?;
@@ -4087,12 +4086,12 @@ pub fn read_oper(in_code: &str) -> (&str, Option<u128>) {
     '<' => match head(tail(code)) {
       '=' => (tail(tail(code)), Some(LTE)),
       '<' => (tail(tail(code)), Some(SHL)),
-      _   => (code, Some(LTN)),
+      _   => (tail(code), Some(LTN)),
     },
     '>' => match head(tail(code)) {
       '=' => (tail(tail(code)), Some(GTE)),
       '>' => (tail(tail(code)), Some(SHR)),
-      _   => (code, Some(GTN)),
+      _   => (tail(code), Some(GTN)),
     },
     '=' => match head(tail(code)) {
       '=' => (tail(tail(code)), Some(EQL)),


### PR DESCRIPTION
Was dropping an extra character after the operator, accepting names like >>< and *$ when it should be an error.
< and > where not dropping a character, which was offset by the extra drop always, so they were fixed as well.