### PR TITLE
implements deletion of heaps (`delete_buffers`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "tempdir",
  "tiny-keccak",
  "tokio",
  "tokio-stream",
@@ -936,6 +937,19 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
 
 [[package]]
 name = "rand"
@@ -1336,6 +1350,16 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +340,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,14 +380,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -597,6 +650,7 @@ dependencies = [
  "priority-queue",
  "proptest",
  "rand 0.8.5",
+ "rstest",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1156,10 +1210,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusty-fork"
@@ -1215,6 +1303,12 @@ checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "tempdir",
  "tiny-keccak",
  "tokio",
  "tokio-stream",
@@ -991,19 +990,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
 
 [[package]]
 name = "rand"
@@ -1444,16 +1430,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,4 @@ warp = "0.3"
 # [dev-dependencies]
 # == TESTS == #
 proptest = "1.0.0"
-tempdir = "0.3.7"
 rstest = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,6 @@ tokio-stream = { version = "0.1.9", features = ["net"] }
 warp = "0.3"
 
 # [dev-dependencies]
+# == TESTS == #
 proptest = "1.0.0"
+tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ warp = "0.3"
 # == TESTS == #
 proptest = "1.0.0"
 tempdir = "0.3.7"
+rstest = "0.15.0"

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -448,6 +448,7 @@ pub struct Runtime {
   curr: u64,            // current heap index
   nuls: Vec<u64>,       // reuse heap indices
   back: Arc<Rollback>,  // past states
+  path: PathBuf,        // where to save runtime state
 }
 
 //pub fn heaps_invariant(rt: &Runtime) -> (bool, Vec<u8>, Vec<u64>) {
@@ -873,10 +874,6 @@ fn absorb_i128(a: i128, b: i128, overwrite: bool) -> i128 {
   if b == I128_NONE { a } else if overwrite || a == I128_NONE { b } else { a }
 }
 
-fn heap_dir_path() -> PathBuf {
-  dirs::home_dir().unwrap().join(".kindelia").join("state").join("heaps")
-}
-
 impl Heap {
   fn write(&mut self, idx: u128, val: u128) {
     return self.memo.write(idx, val);
@@ -1095,59 +1092,58 @@ impl Heap {
       self.write_ownr(fnid, ownr);
     }
   }
-  fn buffer_file_path(&self, uuid: u128, buffer_name: &str) -> PathBuf {
-    heap_dir_path().join(format!("{:0>32x}.{}.bin", uuid, buffer_name))
+  fn buffer_file_path(&self, uuid: u128, buffer_name: &str, path: &PathBuf) -> PathBuf {
+    path.join(format!("{:0>32x}.{}.bin", uuid, buffer_name))
   }
-  fn write_buffer(&self, uuid: u128, buffer_name: &str, buffer: &[u128], append: bool) -> std::io::Result<()> {
+  fn write_buffer(&self, uuid: u128, buffer_name: &str, buffer: &[u128], append: bool, path: &PathBuf) -> std::io::Result<()> {
     use std::io::Write;
-    std::fs::create_dir_all(&heap_dir_path())?;
     std::fs::OpenOptions::new()
       .write(true)
       .append(append)
       .create(true)
-      .open(self.buffer_file_path(self.uuid, buffer_name))?
+      .open(self.buffer_file_path(self.uuid, buffer_name, path))?
       .write_all(&util::u128s_to_u8s(buffer))?;
     return Ok(());
   }
-  fn read_buffer(&self, uuid: u128, buffer_name: &str) -> std::io::Result<Vec<u128>> {
-    std::fs::read(self.buffer_file_path(uuid, buffer_name)).map(|x| util::u8s_to_u128s(&x))
+  fn read_buffer(&self, uuid: u128, buffer_name: &str, path: &PathBuf) -> std::io::Result<Vec<u128>> {
+    std::fs::read(self.buffer_file_path(uuid, buffer_name, path)).map(|x| util::u8s_to_u128s(&x))
   }
-  fn delete_buffer(&self, uuid: u128, buffer_name: &str) -> std::io::Result<()> {
-    std::fs::remove_file(self.buffer_file_path(uuid, buffer_name))
+  fn delete_buffer(&self, uuid: u128, buffer_name: &str, path: &PathBuf) -> std::io::Result<()> {
+    std::fs::remove_file(self.buffer_file_path(uuid, buffer_name, path))
   }
-  pub fn save_buffers(&self) -> std::io::Result<()> {
-    self.append_buffers(self.uuid)
+  pub fn save_buffers(&self, path: &PathBuf) -> std::io::Result<()> {
+    self.append_buffers(self.uuid, path)
   }
-  fn append_buffers(&self, uuid: u128) -> std::io::Result<()> {
+  fn append_buffers(&self, uuid: u128, path: &PathBuf) -> std::io::Result<()> {
     let serial = self.serialize();
-    self.write_buffer(serial.uuid, "memo", &serial.memo, true)?;
-    self.write_buffer(serial.uuid, "disk", &serial.disk, true)?;
-    self.write_buffer(serial.uuid, "file", &serial.file, true)?;
-    self.write_buffer(serial.uuid, "arit", &serial.arit, true)?;
-    self.write_buffer(serial.uuid, "ownr", &serial.ownr, true)?;
-    self.write_buffer(serial.uuid, "nums", &serial.nums, true)?;
-    self.write_buffer(serial.uuid, "stat", &serial.stat, false)?;
+    self.write_buffer(serial.uuid, "memo", &serial.memo, true, path)?;
+    self.write_buffer(serial.uuid, "disk", &serial.disk, true, path)?;
+    self.write_buffer(serial.uuid, "file", &serial.file, true, path)?;
+    self.write_buffer(serial.uuid, "arit", &serial.arit, true, path)?;
+    self.write_buffer(serial.uuid, "ownr", &serial.ownr, true, path)?;
+    self.write_buffer(serial.uuid, "nums", &serial.nums, true, path)?;
+    self.write_buffer(serial.uuid, "stat", &serial.stat, false, path)?;
     return Ok(());
   }
-  pub fn load_buffers(&mut self, uuid: u128) -> std::io::Result<()> {
-    let memo = self.read_buffer(uuid, "memo")?;
-    let disk = self.read_buffer(uuid, "disk")?;
-    let file = self.read_buffer(uuid, "file")?;
-    let arit = self.read_buffer(uuid, "arit")?;
-    let ownr = self.read_buffer(uuid, "ownr")?;
-    let nums = self.read_buffer(uuid, "nums")?;
-    let stat = self.read_buffer(uuid, "stat")?;
+  pub fn load_buffers(&mut self, uuid: u128, path: &PathBuf) -> std::io::Result<()> {
+    let memo = self.read_buffer(uuid, "memo", path)?;
+    let disk = self.read_buffer(uuid, "disk", path)?;
+    let file = self.read_buffer(uuid, "file", path)?;
+    let arit = self.read_buffer(uuid, "arit", path)?;
+    let ownr = self.read_buffer(uuid, "ownr", path)?;
+    let nums = self.read_buffer(uuid, "nums", path)?;
+    let stat = self.read_buffer(uuid, "stat", path)?;
     self.deserialize(&SerializedHeap { uuid, memo, disk, file, arit, ownr, nums, stat });
     return Ok(());
   }
-  fn delete_buffers(&mut self) -> std::io::Result<()> {
-    self.delete_buffer(self.uuid, "memo")?;
-    self.delete_buffer(self.uuid, "disk")?;
-    self.delete_buffer(self.uuid, "file")?;
-    self.delete_buffer(self.uuid, "arit")?;
-    self.delete_buffer(self.uuid, "ownr")?;
-    self.delete_buffer(self.uuid, "nums")?;
-    self.delete_buffer(self.uuid, "stat")?;
+  fn delete_buffers(&mut self, path: &PathBuf) -> std::io::Result<()> {
+    self.delete_buffer(self.uuid, "memo", path)?;
+    self.delete_buffer(self.uuid, "disk", path)?;
+    self.delete_buffer(self.uuid, "file", path)?;
+    self.delete_buffer(self.uuid, "arit", path)?;
+    self.delete_buffer(self.uuid, "ownr", path)?;
+    self.delete_buffer(self.uuid, "nums", path)?;
+    self.delete_buffer(self.uuid, "stat", path)?;
     return Ok(());
   }
 }
@@ -1267,7 +1263,11 @@ impl Ownrs {
   }
 }
 
-pub fn init_runtime() -> Runtime {
+pub fn init_runtime(path: Option<&PathBuf>) -> Runtime {
+  // Default runtime store path
+  let dflt = dirs::home_dir().unwrap().join(".kindelia").join("state").join("heaps");
+  let path = path.unwrap_or_else(|| &dflt);
+  std::fs::create_dir_all(&path).unwrap(); // TODO remove unwrap?
   let mut heap = Vec::new();
   for i in 0 .. MAX_HEAPS {
     heap.push(init_heap());
@@ -1278,6 +1278,7 @@ pub fn init_runtime() -> Runtime {
     curr: 1,
     nuls: (2 .. MAX_HEAPS).collect(),
     back: Arc::new(Rollback::Nil),
+    path: path.clone(),
   };
   rt.run_statements_from_code(GENESIS, true);
   
@@ -1752,13 +1753,14 @@ impl Runtime {
     // println!(" - back {}", view_rollback(&self.back));
     if included {
       self.save_state_metadata().expect("Error saving state metadata.");
-      self.heap[self.curr as usize].save_buffers().expect("Error saving buffers."); // TODO: persistence-WIP
+      let path = &self.get_dir_path();
+      self.heap[self.curr as usize].save_buffers(path).expect("Error saving buffers."); // TODO: persistence-WIP
       if let Some(deleted) = deleted {
         if let Some(absorber) = absorber {
           self.absorb_heap(absorber, deleted, false);
-          self.heap[absorber as usize].append_buffers(self.heap[deleted as usize].uuid).expect("Couldn't append buffers."); // TODO: persistence-WIP
+          self.heap[absorber as usize].append_buffers(self.heap[deleted as usize].uuid, path).expect("Couldn't append buffers."); // TODO: persistence-WIP
         }
-        self.heap[deleted as usize].delete_buffers().expect("Couldn't delete buffers.");
+        self.heap[deleted as usize].delete_buffers(path).expect("Couldn't delete buffers.");
         self.clear_heap(deleted);
         self.curr = deleted;
       } else if let Some(empty) = self.nuls.pop() {
@@ -1778,10 +1780,11 @@ impl Runtime {
       self.clear_heap(self.curr);
       self.nuls.push(self.curr);
       let mut cuts = 0;
+      let path = self.get_dir_path();
       // Removes heaps until the runtime's tick is larger than, or equal to, the target tick
       while tick < self.get_tick() {
         if let Rollback::Cons { keep, life, head, tail } = &*self.back.clone() {
-          self.heap[*head as usize].delete_buffers().expect("Couldn't delete buffers.");
+          self.heap[*head as usize].delete_buffers(&path).expect("Couldn't delete buffers.");
           self.clear_heap(*head);
           self.nuls.push(*head);
           self.back = tail.clone();
@@ -1799,12 +1802,15 @@ impl Runtime {
   // Persistence
   // -----------
 
+  pub fn get_dir_path(&self) -> PathBuf {
+    return self.path.clone();
+  }
+
   // Persists the current state. Since heaps are automatically saved to disk, function only saves
   // their uuids. Note that this will NOT save the current heap, nor anything after the last heap
   // included on the Rollback list. In other words, it forgets up to ~16 recent blocks. This
   // function is used to avoid re-processing the entire block history on node startup.
   pub fn save_state_metadata(&self) -> std::io::Result<()> {
-    std::fs::create_dir_all(&heap_dir_path())?;
     fn build_persistence_buffers(rt: &Runtime, rollback: &Rollback, keeps: &mut Vec<u128>, lifes: &mut Vec<u128>, uuids: &mut Vec<u128>) {
       match rollback {
         Rollback::Cons { keep, life, head, tail } => {
@@ -1820,9 +1826,9 @@ impl Runtime {
     let mut lifes : Vec<u128> = vec![];
     let mut uuids : Vec<u128> = vec![];
     build_persistence_buffers(self, &self.back,  &mut keeps, &mut lifes, &mut uuids);
-    std::fs::write(heap_dir_path().join("_keeps_"), &util::u128s_to_u8s(&keeps))?;
-    std::fs::write(heap_dir_path().join("_lifes_"), &util::u128s_to_u8s(&lifes))?;
-    std::fs::write(heap_dir_path().join("_uuids_"), &util::u128s_to_u8s(&uuids))?;
+    std::fs::write(self.path.join("_keeps_"), &util::u128s_to_u8s(&keeps))?;
+    std::fs::write(self.path.join("_lifes_"), &util::u128s_to_u8s(&lifes))?;
+    std::fs::write(self.path.join("_uuids_"), &util::u128s_to_u8s(&uuids))?;
     return Ok(());
   }
 
@@ -1835,9 +1841,9 @@ impl Runtime {
     // for i in 0 .. std::cmp::max(uuids.len(), 8) {
     //   self.heap[i + 2].load_buffers(uuids[i])?;
     // }
-    let mut keeps = util::u8s_to_u128s(&std::fs::read(heap_dir_path().join("_keeps_"))?);
-    let mut lifes = util::u8s_to_u128s(&std::fs::read(heap_dir_path().join("_lifes_"))?);
-    let mut uuids = util::u8s_to_u128s(&std::fs::read(heap_dir_path().join("_uuids_"))?);
+    let mut keeps = util::u8s_to_u128s(&std::fs::read(self.path.join("_keeps_"))?);
+    let mut lifes = util::u8s_to_u128s(&std::fs::read(self.path.join("_lifes_"))?);
+    let mut uuids = util::u8s_to_u128s(&std::fs::read(self.path.join("_uuids_"))?);
     fn load_heaps(rt: &mut Runtime, keeps: &mut Vec<u128>, lifes: &mut Vec<u128>, uuids: &mut Vec<u128>, index: u64, back: Arc<Rollback>) -> std::io::Result<Arc<Rollback>> {
       let keep = keeps.pop();
       let life = lifes.pop();
@@ -1847,7 +1853,8 @@ impl Runtime {
           let next = rt.nuls.pop();
           match next {
             Some(next) => {
-              rt.heap[index as usize].load_buffers(uuid)?;
+              let path = rt.get_dir_path();
+              rt.heap[index as usize].load_buffers(uuid, &path)?;
               rt.curr = index;
               return load_heaps(rt, keeps, lifes, uuids, next, Arc::new(Rollback::Cons { keep: keep as u64, life: life as u64, head: index, tail: back }));
             }
@@ -4454,7 +4461,7 @@ pub fn test_statements(statements: &[Statement]) {
   println!("=====");
   println!();
 
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(None);
   let init = Instant::now();
   rt.run_statements(&statements, false);
   println!();

--- a/src/node.rs
+++ b/src/node.rs
@@ -638,7 +638,7 @@ impl Node {
       peer_id    : HashMap::new(),
       peers      : HashMap::new(),
       peer_idx   : 0,
-      runtime    : init_runtime(),
+      runtime    : init_runtime(None),
       receiver   : query_receiver,
     };
 

--- a/src/test/hvm.rs
+++ b/src/test/hvm.rs
@@ -4,31 +4,32 @@ use crate::{
   test::{
     strategies::{func, heap, name, statement},
     util::{
-      advance, rollback, rollback_path, rollback_simple, test_heap_checksum, view_rollback_ticks,
-      RuntimeStateTest, TempDir,
+      advance, rollback, rollback_path, rollback_simple, temp_dir, test_heap_checksum,
+      view_rollback_ticks, RuntimeStateTest, TempDir,
     },
   },
 };
 use proptest::collection::vec;
 use proptest::proptest;
+use rstest::rstest;
 
-#[test]
-pub fn simple_rollback() {
+#[rstest]
+pub fn simple_rollback(temp_dir: TempDir) {
   let fn_names = ["Count", "Store", "Sub", "Add"];
-  assert!(rollback_simple(PRE_COUNTER, COUNTER, &fn_names, 1000, 1));
+  assert!(rollback_simple(PRE_COUNTER, COUNTER, &fn_names, 1000, 1, &temp_dir.path));
 }
 
-#[test]
-pub fn advanced_rollback_in_random_state() {
+#[rstest]
+pub fn advanced_rollback_in_random_state(temp_dir: TempDir) {
   let fn_names = ["Count", "Store", "Sub", "Add"];
   let path = [1000, 12, 1000, 24, 1000, 36];
-  assert!(rollback_path(PRE_COUNTER, COUNTER, &fn_names, &path));
+  assert!(rollback_path(PRE_COUNTER, COUNTER, &fn_names, &path, &temp_dir.path));
 }
 
-#[test]
-pub fn advanced_rollback_in_saved_state() {
+#[rstest]
+pub fn advanced_rollback_in_saved_state(temp_dir: TempDir) {
   let fn_names = ["Count", "Store", "Sub", "Add"];
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(Some(&temp_dir.path));
   rt.run_statements_from_code(PRE_COUNTER, true);
   advance(&mut rt, 1000, Some(COUNTER));
   rt.rollback(900);
@@ -49,36 +50,37 @@ pub fn advanced_rollback_in_saved_state() {
   assert_eq!(s2, s3);
 }
 
-#[test]
-pub fn advanced_rollback_run_fail() {
+#[rstest]
+pub fn advanced_rollback_run_fail(temp_dir: TempDir) {
   let fn_names = ["Count", "Store", "Sub", "Add"];
   let path = [2, 1, 2, 1, 2, 1];
-  assert!(rollback_path(PRE_COUNTER, COUNTER, &fn_names, &path));
+  assert!(rollback_path(PRE_COUNTER, COUNTER, &fn_names, &path, &temp_dir.path));
 }
 
-#[test]
-pub fn stack_overflow() {
+#[rstest]
+pub fn stack_overflow(temp_dir: TempDir) {
   // caused by compute_at function
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(Some(&temp_dir.path));
   rt.run_statements_from_code(PRE_COUNTER, true);
   advance(&mut rt, 1000, Some(COUNTER));
 }
 
-#[test]
+#[rstest]
 #[ignore = "fix not done"]
 // TODO: fix drop stack overflow
-pub fn stack_overflow2() {
+pub fn stack_overflow2(temp_dir: TempDir) {
   // caused by drop of term
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(Some(&temp_dir.path));
   rt.run_statements_from_code(PRE_COUNTER, false);
   rt.run_statements_from_code(COUNTER_STACKOVERFLOW, false);
 }
 
-pub fn persistence1(temp_dir_path: TempDir) {
-  println!("{}", temp_dir_path.0.as_path().display());
+#[rstest]
+pub fn persistence1(temp_dir: TempDir) {
+  println!("{}", temp_dir.path.as_path().display());
 
   let fn_names = ["Count", "Store", "Sub", "Add"];
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(Some(&temp_dir.path));
   rt.run_statements_from_code(PRE_COUNTER, true);
 
   advance(&mut rt, 1000, Some(COUNTER));
@@ -101,11 +103,11 @@ pub fn persistence1(temp_dir_path: TempDir) {
   assert_eq!(s3, s5);
 }
 
-#[test]
-fn one_hundred_snapshots() {
+#[rstest]
+fn one_hundred_snapshots(temp_dir: TempDir) {
   // run this with rollback in each 4th snapshot
   // note: this test has no state
-  let mut rt = init_runtime();
+  let mut rt = init_runtime(Some(&temp_dir.path));
   for i in 0..100000 {
     rt.tick();
     println!(" - tick: {}, - rollback: {}", rt.get_tick(), view_rollback_ticks(&rt));

--- a/src/test/hvm.rs
+++ b/src/test/hvm.rs
@@ -12,8 +12,6 @@ use crate::{
 use proptest::collection::vec;
 use proptest::proptest;
 
-use super::util::temp_dir_path;
-
 #[test]
 pub fn simple_rollback() {
   let fn_names = ["Count", "Store", "Sub", "Add"];

--- a/src/test/strategies.rs
+++ b/src/test/strategies.rs
@@ -1,8 +1,18 @@
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
 use crate::{
   crypto,
-  hvm::{name_to_u128, Func, Rule, Statement, Term},
+  hvm::{
+    init_map, name_to_u128, Arits, CompFunc, CompRule, Func, Funcs, Heap, Map, Nodes, Ownrs,
+    Rollback, Rule, Runtime, SerializedHeap, Statement, Store, Term, Var,
+  },
 };
-use proptest::{arbitrary::any, collection::vec, option, prop_oneof, strategy::Strategy};
+use proptest::{
+  arbitrary::any,
+  collection::{hash_map, vec},
+  option, prop_oneof,
+  strategy::{Just, Strategy},
+};
 
 // generate valid names
 pub fn name() -> impl Strategy<Value = u128> {
@@ -38,9 +48,13 @@ pub fn term() -> impl Strategy<Value = Term> {
   )
 }
 
+fn fun() -> impl Strategy<Value = Term> {
+  (name(), vec(term(), 0..32)).prop_map(|(n, b)| Term::Fun { name: n, args: b })
+}
+
 // generate rules
 pub fn rule() -> impl Strategy<Value = Rule> {
-  (term(), term()).prop_map(|(lhs, rhs)| Rule { lhs, rhs })
+  (fun(), term()).prop_map(|(lhs, rhs)| Rule { lhs, rhs })
 }
 
 pub fn func() -> impl Strategy<Value = Func> {
@@ -64,4 +78,86 @@ pub fn statement() -> impl Strategy<Value = Statement> {
     (name(), name(), option::of(sign()))
       .prop_map(|(name, ownr, sign)| { Statement::Reg { name, ownr, sign } }),
   ]
+}
+
+pub fn nodes() -> impl Strategy<Value = Nodes> {
+  (map(any::<u128>())).prop_map(|m| Nodes { nodes: m })
+}
+
+pub fn map<A: std::fmt::Debug>(s: impl Strategy<Value = A>) -> impl Strategy<Value = Map<A>> {
+  vec((any::<u128>(), s), 0..10).prop_map(|v| {
+    let mut m = init_map();
+    for (k, v) in v {
+      m.insert(k, v);
+    }
+    m
+  })
+}
+
+pub fn store() -> impl Strategy<Value = Store> {
+  map(any::<u128>()).prop_map(|m| Store { links: m })
+}
+
+pub fn arits() -> impl Strategy<Value = Arits> {
+  map(any::<u128>()).prop_map(|m| Arits { arits: m })
+}
+
+pub fn ownrs() -> impl Strategy<Value = Ownrs> {
+  map(any::<u128>()).prop_map(|m| Ownrs { ownrs: m })
+}
+
+pub fn var() -> impl Strategy<Value = Var> {
+  (name(), any::<u128>(), option::of(any::<u128>()), any::<bool>()).prop_map(|(n, p, f, e)| Var {
+    name: n,
+    param: p,
+    field: f,
+    erase: e,
+  })
+}
+
+pub fn comp_rule() -> impl Strategy<Value = CompRule> {
+  (vec(any::<u128>(), 0..32), vec(var(), 0..32), vec((any::<u128>(), any::<u128>()), 0..32), term())
+    .prop_map(|(c, v, e, b)| CompRule { cond: c, vars: v, eras: e, body: b })
+}
+
+pub fn comp_func() -> impl Strategy<Value = CompFunc> {
+  (func(), any::<u128>(), vec(any::<u128>(), 0..32), vec(comp_rule(), 0..32))
+    .prop_map(|(f, a, r, s)| CompFunc { func: f, arity: a, redux: r, rules: s })
+}
+
+pub fn funcs() -> impl Strategy<Value = Funcs> {
+  map(comp_func().prop_map(|cf| Arc::new(cf))).prop_map(|m| Funcs { funcs: m })
+}
+
+pub fn heap() -> impl Strategy<Value = Heap> {
+  let tuple_strategy = (
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<u128>(),
+    any::<i128>(),
+  );
+
+  (tuple_strategy, nodes(), store(), arits(), ownrs(), funcs()).prop_map(
+    |((uuid, mcap, tick, funs, dups, rwts, mana, next, size), memo, disk, arit, ownr, file)| Heap {
+      mcap,
+      disk,
+      arit,
+      ownr,
+      file: Funcs { funcs: init_map() }, // TODO, fix?
+      uuid,
+      memo,
+      tick,
+      funs,
+      dups,
+      rwts,
+      mana,
+      size,
+      next,
+    },
+  )
 }

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -216,11 +216,3 @@ impl Drop for TempDir {
     }
   }
 }
-
-#[fixture]
-pub fn temp_dir_path() -> TempDir {
-  let rand_id = fastrand::u128(..);
-  let path = temp_dir().join(format!("{:0>32x}", rand_id));
-  std::fs::create_dir_all(&path).unwrap();
-  TempDir(path)
-}

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -215,8 +215,8 @@ pub fn rollback_path(
 
 // This struct is created just to wrap Pathbuf and
 // be able to remove the dir when it is dropped
-pub struct TempDir{
-  pub path: PathBuf
+pub struct TempDir {
+  pub path: PathBuf,
 }
 
 impl Drop for TempDir {
@@ -234,8 +234,8 @@ impl Drop for TempDir {
 // before each test that uses it as a parameter
 #[fixture]
 pub fn temp_dir() -> TempDir {
-  let path = tempdir::TempDir::new("kindelia").unwrap().into_path();
-  let temp_dir = TempDir{ path };
+  let path = std::env::temp_dir().join(format!("kindelia.{:x}", fastrand::u128(..)));
+  let temp_dir = TempDir { path };
   println!("Temp dir: {:?}", temp_dir.path);
   temp_dir
 }


### PR DESCRIPTION
With this PR heaps are now deleted when absorbed and when discarded by rollback. So, in the system directory, only the actual rollback heaps are stored; then the `restore_state` function had to be modified to only restore the last rollback saved at runtime (before this it was possible to pass a heap uuid to restore it, but with the deletion of the heaps, only the ones that appear in the current rollback exist in the file system, so such logic no longer makes sense).

This PR also fix the test for persistence with this new deletion logic.

Temp dirs are now used in tests to avoid confusion in `cargo test` command, since this runs in parallel, and to remove unnecessary files. To do this a new property was added in Runtime's struct to store in which directory this Runtime should save its contents.