### PR TITLE
refactoring `u128`s to newtypes

### DIFF
--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -1,9 +1,3 @@
-#![warn(dead_code)]
-#![warn(unused_imports)]
-#![warn(non_snake_case)]
-#![warn(unused_variables)]
-#![warn(clippy::style)]
-#![allow(clippy::let_and_return)]
 
 use std::sync::mpsc::SyncSender;
 
@@ -16,8 +10,8 @@ use warp::reply::{self, Reply};
 use warp::{body, path, post, Filter};
 use warp::{reject, Rejection};
 
-use super::{name_to_u128, NodeRequest};
-use crate::hvm::{self, Name};
+use super::NodeRequest;
+use crate::hvm::{self, Name, name_to_u128};
 use crate::util::U256;
 
 // Util

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,14 @@
+#![warn(dead_code)]
+#![warn(unused_imports)]
+#![warn(non_snake_case)]
+#![warn(unused_variables)]
+#![warn(clippy::style)]
+#![allow(clippy::let_and_return)]
+
 pub mod http;
 pub mod serialization;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::sync::mpsc::SyncSender;
 
@@ -10,12 +17,10 @@ use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 use tokio::sync::oneshot;
 
-use crate::hvm::{self, Name, name_to_u128};
+use crate::hvm::{self, Name};
 use crate::node;
 
 use self::serialization::u256_to_hex;
-
-type NodeRequester = SyncSender<NodeRequest>;
 
 // Basic
 // =====

--- a/src/api/serialization.rs
+++ b/src/api/serialization.rs
@@ -38,7 +38,7 @@ pub fn name_to_u128_safe(name: &str) -> Option<u128> {
   if name.len() > 20 {
     None
   } else {
-    Some(hvm::name_to_u128(name))
+    Some(hvm::name_to_u128_unsafe(name))
   }
 }
 
@@ -58,8 +58,8 @@ impl serde::Serialize for Statement {
       // TODO: serialize sign
       Statement::Fun { name, args, func, init, sign: _ } => {
         let mut s = serializer.serialize_struct_variant("Statement", 0, "Fun", 4)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
-        s.serialize_field("args", &u128_names_to_strings(args))?;
+        s.serialize_field("name", name)?;
+        s.serialize_field("args", args)?;
         s.serialize_field("func", func)?;
         s.serialize_field("init", init)?;
         s.end()
@@ -67,8 +67,8 @@ impl serde::Serialize for Statement {
       // TODO: serialize sign
       Statement::Ctr { name, args, sign: _ } => {
         let mut s = serializer.serialize_struct_variant("Statement", 1, "Ctr", 2)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
-        s.serialize_field("args", &u128_names_to_strings(args))?;
+        s.serialize_field("name", name)?;
+        s.serialize_field("args", args)?;
         s.end()
       }
       // TODO: serialize sign
@@ -116,20 +116,20 @@ impl serde::Serialize for Term {
     match self {
       Term::Var { name } => {
         let mut s = serializer.serialize_struct_variant("Term", 0, "Var", 1)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
+        s.serialize_field("name", name)?;
         s.end()
       }
       Term::Dup { nam0, nam1, expr, body } => {
         let mut s = serializer.serialize_struct_variant("Term", 1, "Dup", 4)?;
-        s.serialize_field("nam0", &u128_to_name(*nam0))?;
-        s.serialize_field("nam1", &u128_to_name(*nam1))?;
+        s.serialize_field("nam0", nam0)?;
+        s.serialize_field("nam1", nam1)?;
         s.serialize_field("expr", &expr)?;
         s.serialize_field("body", &body)?;
         s.end()
       }
       Term::Lam { name, body } => {
         let mut s = serializer.serialize_struct_variant("Term", 2, "Lam", 2)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
+        s.serialize_field("name", name)?;
         s.serialize_field("body", &body)?;
         s.end()
       }
@@ -141,13 +141,13 @@ impl serde::Serialize for Term {
       }
       Term::Ctr { name, args } => {
         let mut s = serializer.serialize_struct_variant("Term", 4, "Ctr", 2)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
+        s.serialize_field("name", name)?;
         s.serialize_field("args", args)?;
         s.end()
       }
       Term::Fun { name, args } => {
         let mut s = serializer.serialize_struct_variant("Term", 5, "Fun", 2)?;
-        s.serialize_field("name", &u128_to_name(*name))?;
+        s.serialize_field("name", name)?;
         s.serialize_field("args", args)?;
         s.end()
       }

--- a/src/api/serialization.rs
+++ b/src/api/serialization.rs
@@ -1,9 +1,6 @@
 use serde::ser::{SerializeStruct, SerializeStructVariant};
-use serde::Serialize;
 
-use super::{BlockInfo, FuncInfo, Stats};
-use crate::hvm::{self, u128_to_name, Func, Rule, Statement, StatementErr, StatementInfo, Term};
-use crate::node::Block;
+use crate::hvm::{self, Func, Rule, Statement, Term};
 use crate::util::U256;
 
 // Util
@@ -16,35 +13,20 @@ pub fn u256_to_hex(value: &U256) -> String {
   format!("0x{}", hex::encode(be_bytes))
 }
 
-// Hexadecimal string to U256
-pub fn hex_to_u256(hex: &str) -> Result<U256, String> {
-  let bytes = hex::decode(hex);
-  let bytes = match bytes {
-    Ok(bytes) => bytes,
-    Err(_) => return Err(format!("Invalid hexadecimal string: '{}'", hex)),
-  };
-  if bytes.len() != 256 / 8 {
-    Err(format!("Invalid hexadecimal string: {}", hex))
-  } else {
-    let num = U256::from_big_endian(&bytes);
-    Ok(num)
-  }
-}
-
-// HVM
-// ===
-
-pub fn name_to_u128_safe(name: &str) -> Option<u128> {
-  if name.len() > 20 {
-    None
-  } else {
-    Some(hvm::name_to_u128_unsafe(name))
-  }
-}
-
-pub fn u128_names_to_strings(names: &[u128]) -> Vec<String> {
-  names.iter().copied().map(hvm::u128_to_name).collect::<Vec<_>>()
-}
+// // Hexadecimal string to U256
+// pub fn hex_to_u256(hex: &str) -> Result<U256, String> {
+//   let bytes = hex::decode(hex);
+//   let bytes = match bytes {
+//     Ok(bytes) => bytes,
+//     Err(_) => return Err(format!("Invalid hexadecimal string: '{}'", hex)),
+//   };
+//   if bytes.len() != 256 / 8 {
+//     Err(format!("Invalid hexadecimal string: {}", hex))
+//   } else {
+//     let num = U256::from_big_endian(&bytes);
+//     Ok(num)
+//   }
+// }
 
 // Serde Implementations
 // =====================

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -95,12 +95,12 @@ pub fn deserialize_bits(bits: &BitVec, index: &mut u128, names: &mut Names) -> O
 
 // A name is grouped by 6-bit letters
 
-pub fn serialize_name(name: &u128, bits: &mut BitVec, names: &mut Names) {
+pub fn serialize_name(name: &Name, bits: &mut BitVec, names: &mut Names) {
   if let Some(id) = names.get(name) {
     bits.push(true);
     serialize_varlen(&u256(*id), bits, names);
   } else {
-    let mut name = *name;
+    let mut name = **name;
     names.insert(name, names.len() as u128);
     bits.push(false); // compressed-name flag
     while name > 0 {
@@ -112,7 +112,7 @@ pub fn serialize_name(name: &u128, bits: &mut BitVec, names: &mut Names) {
   }
 }
 
-pub fn deserialize_name(bits: &BitVec, index: &mut u128, names: &mut Names) -> Option<u128> {
+pub fn deserialize_name(bits: &BitVec, index: &mut u128, names: &mut Names) -> Option<Name> {
   let mut nam : u128 = 0;
   let mut add : u128 = 1;
   let compressed = bits.get(*index as usize)?;
@@ -120,7 +120,7 @@ pub fn deserialize_name(bits: &BitVec, index: &mut u128, names: &mut Names) -> O
   if compressed {
     let id = deserialize_varlen(bits, index, names)?.low_u128();
     let nm = *names.get(&id)?;
-    return Some(nm);
+    return Some(Name::from_u128_unchecked(nm));
   } else {
     while bits.get(*index as usize)? {
       *index += 1;
@@ -131,7 +131,7 @@ pub fn deserialize_name(bits: &BitVec, index: &mut u128, names: &mut Names) -> O
     *index = *index + 1;
     if add > 1 {
       names.insert(names.len() as u128, nam);
-      return Some(nam);
+      return Some(Name::from_u128_unchecked(nam));
     } else {
       return None;
     };

--- a/src/node.rs
+++ b/src/node.rs
@@ -910,8 +910,8 @@ impl Node {
     Some(info)
   }
 
-  pub fn get_func_info(&self, fid: u128) -> Option<FuncInfo> {
-    let comp_func = self.runtime.read_file(fid)?;
+  pub fn get_func_info(&self, name: &Name) -> Option<FuncInfo> {
+    let comp_func = self.runtime.read_file(name)?;
     let func = comp_func.func;
     Some(FuncInfo { func })
   }
@@ -951,7 +951,7 @@ impl Node {
         tx.send(funcs).unwrap();
       },
       NodeRequest::GetFunction { name, tx: answer } =>  {
-        let info = self.get_func_info(name);
+        let info = self.get_func_info(&name);
         answer.send(info).unwrap();
       },
       NodeRequest::GetState { name, tx: answer } => {

--- a/src/test/hvm.rs
+++ b/src/test/hvm.rs
@@ -1,7 +1,7 @@
 use crate::{
   bits::{deserialized_func, serialized_func},
   hvm::{
-    init_map, init_runtime, name_to_u128, read_statements, u128_to_name, view_statements, Rollback,
+    init_map, init_runtime, name_to_u128_unsafe, read_statements, u128_to_name, view_statements, Rollback,
   },
   test::{
     strategies::{func, heap, name, statement, term},
@@ -173,8 +173,9 @@ fn parse_ask_fail1(
 proptest! {
   #[test]
   fn name_conversion(name in name()) {
+    let name = *name;
     let a = u128_to_name(name);
-    let b = name_to_u128(&a);
+    let b = name_to_u128_unsafe(&a);
     let c = u128_to_name(b);
     assert_eq!(name, b);
     assert_eq!(a, c);

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -1,6 +1,6 @@
 use rstest::fixture;
 
-use crate::hvm::{init_runtime, name_to_u128, show_term, Rollback, Runtime, U128_NONE};
+use crate::hvm::{init_runtime, name_to_u128_unsafe, show_term, Rollback, Runtime, U128_NONE, Name};
 use std::{
   collections::{hash_map::DefaultHasher, HashMap},
   hash::{Hash, Hasher},
@@ -75,7 +75,8 @@ impl RuntimeStateTest {
 
 // Generate a checksum for a runtime state (for testing)
 pub fn test_heap_checksum(fn_names: &[&str], rt: &mut Runtime) -> u64 {
-  let fn_ids = fn_names.iter().map(|x| name_to_u128(x)).collect::<Vec<u128>>();
+  let fn_ids =
+    fn_names.iter().map(|x| Name::from_u128_unchecked(name_to_u128_unsafe(x))).collect::<Vec<Name>>();
   let mut hasher = DefaultHasher::new();
   for fn_id in fn_ids {
     let term_lnk = rt.read_disk(fn_id);


### PR DESCRIPTION
Refactor needed to simplify the deserialization of all structures on the API boundary.

I have changed most `u128`s that represent names to a newtype called `Name` that implements the relevant traits and will be responsible for the conversion `str <--> u128`.

It implements `Deref<Target = u128>` so one can get the `u128` from a `Name` with just `*name`. Also, `&Name` references will automatically convert to `&u128`.

There are also `Name::is_empty()`, `Name::EMPTY` == `Name(0)` and `Name::NONE` == `Name(VAR_NONE)`.

TODO:
- [ ] handle the rest of `u128`s inside `Term`
- [ ] drop Serialize implementations in favor of Serde derive macros