### PR TITLE
add readback tests cases - closes #115

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,10 @@
+# uses hyperfine to compare two branches
+# you can use this as `./scripts/bench.sh refactor-name 'cargo run --profile=dev_fast -- run example/block_1.kdl'`
+hyperfine \
+  --warmup 1 \
+  -n "master" \
+  --prepare "git checkout master" \
+  "$2" \
+  -n $1 \
+  --prepare "git checkout $1" \
+  "$2" \

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -1,0 +1,4 @@
+# to execute this script install llvm-cov with
+# cargo install cargo-llvm-cov
+# you can use it as `./script/cov` or `./script/cov test::hvm` (runs only hvm tests)
+cargo llvm-cov --open --profile=dev_fast -- $1

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,7 +10,6 @@ pub mod serialization;
 
 use std::collections::HashSet;
 use std::fmt::{self, Display};
-use std::sync::mpsc::SyncSender;
 
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
@@ -40,9 +39,9 @@ impl From<U256> for Hash {
   }
 }
 
-impl Into<U256> for Hash {
-  fn into(self) -> U256 {
-    self.value
+impl From<Hash> for U256 {
+  fn from(hash: Hash) -> Self {
+      hash.value
   }
 }
 
@@ -69,9 +68,9 @@ impl TryFrom<&str> for Hash {
   }
 }
 
-impl Into<String> for Hash {
-  fn into(self) -> String {
-    u256_to_hex(&self.value)
+impl From<Hash> for String {
+  fn from(hash: Hash) -> Self {
+    u256_to_hex(&hash.value)
   }
 }
 
@@ -95,9 +94,9 @@ pub struct Stats {
   pub tick: u64,
 }
 
-impl Into<String> for &node::Transaction {
-  fn into(self) -> String {
-    hex::encode(&self.data)
+impl From<&node::Transaction> for String {
+  fn from(transaction: &node::Transaction) -> Self {
+    hex::encode(&transaction.data)
   }
 }
 

--- a/src/api/serialization.rs
+++ b/src/api/serialization.rs
@@ -1,6 +1,6 @@
 use serde::ser::{SerializeStruct, SerializeStructVariant};
 
-use crate::hvm::{self, Func, Rule, Statement, Term};
+use crate::hvm::{Func, Rule, Statement, Term};
 use crate::util::U256;
 
 // Util

--- a/src/node.rs
+++ b/src/node.rs
@@ -849,7 +849,7 @@ impl Node {
     self.runtime.set_meta(block.meta >> 8);
     self.runtime.set_hax0((block.hash >>   0).low_u128() >> 8);
     self.runtime.set_hax1((block.hash >> 120).low_u128() >> 8);
-    let result = self.runtime.run_statements(&statements, false);
+    let result = self.runtime.run_statements(&statements, false, false);
     self.results.insert(block.hash, result);
     self.runtime.tick();
   }

--- a/src/test/strategies.rs
+++ b/src/test/strategies.rs
@@ -36,7 +36,7 @@ pub fn fun_name() -> impl Strategy<Value = Name> {
     .prop_map(|s| Name::from_u128_unchecked(s))
 }
 
-// generate valid terms
+// generate terms
 pub fn term() -> impl Strategy<Value = Term> {
   let leaf = prop_oneof![
     name().prop_map(|n| Term::Var { name: n }),

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -99,13 +99,13 @@ pub fn rollback(rt: &mut Runtime, tick: u128, pre_code: Option<&str>, code: Opti
   rt.rollback(tick);
   if rt.get_tick() == 0 {
     if let Some(pre_code) = pre_code {
-      rt.run_statements_from_code(pre_code, true);
+      rt.run_statements_from_code(pre_code, true, true);
     }
   }
   let tick_diff = tick - rt.get_tick();
   for _ in 0..tick_diff {
     if let Some(code) = code {
-      rt.run_statements_from_code(code, true);
+      rt.run_statements_from_code(code, true, true);
     }
     rt.tick();
   }
@@ -118,7 +118,7 @@ pub fn advance(rt: &mut Runtime, tick: u128, code: Option<&str>) {
   let actual_tick = rt.get_tick();
   for _ in actual_tick..tick {
     if let Some(code) = code {
-      rt.run_statements_from_code(code, true);
+      rt.run_statements_from_code(code, true, true);
     }
     rt.tick();
   }
@@ -146,9 +146,9 @@ pub fn rollback_simple(
 
   // Calculate all total_tick states and saves old checksum
   let mut old_state = RuntimeStateTest::new(fn_names, &mut rt);
-  rt.run_statements_from_code(pre_code, true);
+  rt.run_statements_from_code(pre_code, true, true);
   for _ in 0..total_tick {
-    rt.run_statements_from_code(code, true);
+    rt.run_statements_from_code(code, true, true);
     rt.tick();
     // dbg!(test_heap_checksum(&fn_names, &mut rt));
     if rt.get_tick() == rollback_tick {
@@ -158,12 +158,12 @@ pub fn rollback_simple(
   // Does rollback to nearest rollback_tick saved state
   rt.rollback(rollback_tick);
   if rt.get_tick() == 0 {
-    rt.run_statements_from_code(pre_code, true);
+    rt.run_statements_from_code(pre_code, true, true);
   }
   // Run until rollback_tick
   let tick_diff = rollback_tick - rt.get_tick();
   for _ in 0..tick_diff {
-    rt.run_statements_from_code(code, true);
+    rt.run_statements_from_code(code, true, true);
     rt.tick();
   }
   // Calculates new checksum, after rollback
@@ -194,7 +194,7 @@ pub fn rollback_path(
   };
 
   let mut rt = init_runtime(Some(dir_path));
-  rt.run_statements_from_code(pre_code, true);
+  rt.run_statements_from_code(pre_code, true, true);
 
   for tick in path {
     let tick = *tick;


### PR DESCRIPTION
This also:
- increase coverage of compute_at and reduce functions
- fix lints warnings
- add script for benchmarking two different branches
- add script for get coverage