### PR TITLE
Refactor op2

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -455,6 +455,7 @@ pub fn deserialize_term(bits: &BitVec, index: &mut u128, names: &mut Names) -> O
     }
     7 => {
       let oper = deserialize_fixlen(4, bits, index, names)?.low_u128();
+      let oper = oper.try_into().ok()?;
       let val0 = Box::new(deserialize_term(bits, index, names)?);
       let val1 = Box::new(deserialize_term(bits, index, names)?);
       Some(Term::Op2 { oper, val0, val1 })

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -477,8 +477,7 @@ pub struct Runtime {
 pub enum RuntimeError {
   NotEnoughMana,
   NotEnoughSpace,
-  EffectFailure,
-  InvalidOperation
+  EffectFailure
 }
 
 //pub fn heaps_invariant(rt: &Runtime) -> (bool, Vec<u8>, Vec<u64>) {
@@ -3443,7 +3442,7 @@ pub fn reduce(rt: &mut Runtime, root: u128, mana: u128) -> Result<Ptr, RuntimeEr
           if get_tag(arg0) == NUM && get_tag(arg1) == NUM {
             //eprintln!("op2-num");
             rt.set_mana(rt.get_mana() + Op2NumMana());
-            let op  = get_ext(term).try_into().map_err(|_| RuntimeError::InvalidOperation)?;
+            let op  = get_ext(term).try_into().expect("Invalid operation coming from HVM");
             let a_u = get_num(arg0);
             let b_u = get_num(arg1);
             let res = match op {
@@ -4001,7 +4000,6 @@ fn show_runtime_error(err: RuntimeError) -> String {
     RuntimeError::NotEnoughMana => "Not enough mana.",
     RuntimeError::NotEnoughSpace => "Not enough space.",
     RuntimeError::EffectFailure => "Runtime effect failure.",
-    RuntimeError::InvalidOperation => "Tried to execute an invalid operation"
   }).to_string()
 }
 

--- a/src/test/strategies.rs
+++ b/src/test/strategies.rs
@@ -4,7 +4,7 @@ use crate::{
   crypto,
   hvm::{
     init_map, name_to_u128_unsafe, Arits, CompFunc, CompRule, Func, Funcs, Heap, Map, Name, Nodes,
-    Ownrs, Rollback, Rule, Runtime, SerializedHeap, Statement, Store, Term, Var, U120,
+    Ownrs, Rollback, Rule, Runtime, SerializedHeap, Statement, Store, Term, Var, U120, Oper,
   },
   node::{hash_bytes, Address, Block, Body, Message, Peer, Transaction},
 };
@@ -63,12 +63,16 @@ pub fn term() -> impl Strategy<Value = Term> {
           .prop_map(|(n, v)| { Term::Ctr { name: n, args: v } }),
         (small_name(), vec(inner.clone(), 0..10))
           .prop_map(|(n, v)| { Term::Fun { name: n, args: v } }),
-        (0..15_u128, inner.clone(), inner).prop_map(|(o, v0, v1)| {
+        (oper(), inner.clone(), inner).prop_map(|(o, v0, v1)| {
           Term::Op2 { oper: o, val0: Box::new(v0), val1: Box::new(v1) }
         }),
       ]
     },
   )
+}
+
+fn oper() -> impl Strategy<Value = Oper> {
+  (0_u128..16_u128).prop_map(|v| v.try_into().unwrap())
 }
 
 fn fun() -> impl Strategy<Value = Term> {

--- a/src/test/strategies.rs
+++ b/src/test/strategies.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, ops::Range};
 
 use crate::{
   crypto,
@@ -69,6 +69,14 @@ pub fn term() -> impl Strategy<Value = Term> {
       ]
     },
   )
+}
+
+pub fn op2(operator: Range<u128>) -> impl Strategy<Value = Term> {
+  (operator, u120(), u120()).prop_map(|(op, a, b)| Term::Op2 {
+    oper: op.try_into().unwrap(),
+    val0: Box::new(Term::Num { numb: a }),
+    val1: Box::new(Term::Num { numb: b }),
+  })
 }
 
 fn oper() -> impl Strategy<Value = Oper> {


### PR DESCRIPTION
This PR:
- changes oper in Term::Op2 from u128 to enum Oper
- adds op2 tests
- improves matching in operations 
- ~~also creates a `RuntimeError::InvalidOperation`~~