### PR TITLE
change CI to do tests with `dev_fast` profile

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -36,7 +36,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --profile=dev_fast
 
   cargo_clippy:
     name: 👃 Cargo Clippy


### PR DESCRIPTION
This change makes tests run faster in CI. The image below shows that all the test process on ubuntu lasted ~1min, while the same task lasts 7-9min now, both with cache.

<img width="1265" alt="Captura de Tela 2022-08-26 às 14 56 18" src="https://user-images.githubusercontent.com/45523492/186964901-69b39271-299e-4a79-9b61-c564877a9ea4.png">
