### PR TITLE
some CLI TODO's

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,7 +388,6 @@ pub fn run_cli() -> Result<(), String> {
     }
     CLICommand::RunRemote { file, hex } => {
       // TODO: client timeout
-      // TODO: Displat for StatementInfo + print each in one line
       let results = run_on_remote!(file, hex, run_code)?;
       for result in results {
         println!("{}", result);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,8 +389,10 @@ pub fn run_cli() -> Result<(), String> {
     CLICommand::RunRemote { file, hex } => {
       // TODO: client timeout
       // TODO: Displat for StatementInfo + print each in one line
-      let res = run_on_remote!(file, hex, run_code)?;
-      println!("{:?}", res);
+      let results = run_on_remote!(file, hex, run_code)?;
+      for result in results {
+        println!("{}", result);
+      }
       Ok(())
     }
     CLICommand::Publish { file, hex } => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,9 @@ pub enum CLICommand {
   Test {
     /// The path to the file to test.
     file: PathBuf,
+    /// Whether to consider size and mana in the execution.
+    #[clap(long)]
+    debug: bool
   },
   /// Serialize a code file.
   Serialize {
@@ -343,8 +346,8 @@ pub fn run_cli() -> Result<(), String> {
   .get_value_config()?;
 
   match parsed.command {
-    CLICommand::Test { file } => {
-      test_code(&file); // TODO: should get string of code not file / use `from_file_or_stdin` + return Result
+    CLICommand::Test { file, debug } => {
+      test_code(&file, debug); // TODO: should get string of code not file / use `from_file_or_stdin` + return Result
       Ok(())
     }
     CLICommand::Serialize { file } => {
@@ -602,15 +605,14 @@ pub fn post_udp(content: &str, host: Option<String>) -> Result<(), String> {
   Ok(())
 }
 
-pub fn test_code(file: &Path) {
+pub fn test_code(file: &Path, debug: bool) {
   let file = std::fs::read_to_string(file);
   match file {
     Err(err) => {
       eprintln!("{}", err);
     }
     Ok(code) => {
-      // TODO: flag to disable size limit / debug
-      hvm::test_statements_from_code(&code);
+      hvm::test_statements_from_code(&code, debug);
     }
   }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -493,7 +493,7 @@ pub async fn get_info(
     GetKind::Fun { name, stat } => match stat {
       GetFnKind::Code => {
         let func_info =
-          client.get_function(name).await.map_err(|e| e.to_string())?;
+          client.get_function(name).await?;
         if json {
           println!("{}", serde_json::to_string(&func_info).unwrap());
         } else {
@@ -511,7 +511,7 @@ pub async fn get_info(
       }
       GetFnKind::State => {
         let state =
-          client.get_function_state(name).await.map_err(|e| e.to_string())?;
+          client.get_function_state(name).await?;
         if json {
           println!("{}", serde_json::to_string_pretty(&state).unwrap());
         } else {
@@ -525,35 +525,35 @@ pub async fn get_info(
     GetKind::Block { hash: _ } => todo!(),
     GetKind::Ctr { name: _, stat: _ } => todo!(),
     GetKind::Tick => {
-      let stats = client.get_stats().await.map_err(|e| e.to_string())?;
+      let stats = client.get_stats().await?;
       println!("{}", stats.tick);
       Ok(())
     }
     GetKind::Mana => {
-      let stats = client.get_stats().await.map_err(|e| e.to_string())?;
+      let stats = client.get_stats().await?;
       println!("{}", stats.mana);
       Ok(())
     }
     GetKind::Size => {
-      let stats = client.get_stats().await.map_err(|e| e.to_string())?;
+      let stats = client.get_stats().await?;
       println!("{}", stats.size);
       Ok(())
     }
     GetKind::FnCount => {
       let stats_count =
-        client.count_stats().await.map_err(|e| e.to_string())?;
+        client.count_stats().await?;
       println!("{}", stats_count.fn_count);
       Ok(())
     }
     GetKind::NsCount => {
       let stats_count =
-        client.count_stats().await.map_err(|e| e.to_string())?;
+        client.count_stats().await?;
       println!("{}", stats_count.ns_count);
       Ok(())
     }
     GetKind::CtCount => {
       let stats_count =
-        client.count_stats().await.map_err(|e| e.to_string())?;
+        client.count_stats().await?;
       println!("{}", stats_count.ct_count);
       Ok(())
     }

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -1201,6 +1201,21 @@ pub fn set_sign(statement: &Statement, new_sign: crypto::Signature) -> Statement
   }
 }
 
+// StatementInfo
+// =============
+
+impl fmt::Display for StatementInfo {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      StatementInfo::Ctr { name, args } => write!(f, "[ctr] {}", name),
+      StatementInfo::Fun { name, args } => write!(f, "[fun] {}", name),
+      StatementInfo::Reg { name, .. } => write!(f, "[reg] {}", name),
+      StatementInfo::Run { done_term, used_mana, size_diff, .. } =>
+        write!(f, "[run] {} \x1b[2m[{} mana | {} size]\x1b[0m", view_term(&done_term), used_mana, size_diff)
+    }
+  }
+}
+
 // Rollback
 // --------
 
@@ -2029,7 +2044,7 @@ impl Runtime {
       return Err(StatementErr { err });
     }
     let hash = hash_statement(statement);
-    match statement {
+    let res = match statement {
       Statement::Fun { name, args, func, init, sign } => {
         if self.exists(name) {
           return error(self, "fun", format!("Can't redefine '{}'.", name));
@@ -2046,15 +2061,12 @@ impl Runtime {
           return error(self, "fun", format!("Invalid function {}.", name));
         }
         let func = func.unwrap();
-        if !silent {
-          println!("[fun] {}", name);
-        }
         self.set_arity(*name, args.len() as u128);
         self.define_function(*name, func);
         let state = self.create_term(init, 0, &mut init_map());
         self.write_disk(*name, state);
         let args = args.iter().map(|x| *x).collect::<Vec<_>>();
-        Ok(StatementInfo::Fun { name: *name, args })
+        StatementInfo::Fun { name: *name, args }
       }
       Statement::Ctr { name, args, sign } => {
         if self.exists(name) {
@@ -2067,13 +2079,10 @@ impl Runtime {
         if args.len() > 16 {
           return error(self, "ctr", format!("Can't define contructor with arity larger than 16."));
         }
-        if !silent {
-          println!("[ctr] {}", name);
-        }
         let name = *name;
         self.set_arity(name, args.len() as u128);
         let args = args.iter().map(|x| *x).collect::<Vec<_>>();
-        Ok(StatementInfo::Ctr { name, args })
+        StatementInfo::Ctr { name, args }
       }
       Statement::Run { expr, sign } => {
         let mana_ini = self.get_mana(); 
@@ -2103,15 +2112,12 @@ impl Runtime {
         if size_end > size_lim && !debug {
           return error(self, "run", format!("Not enough space."));
         }
-        if !silent {
-          println!("[run] {} \x1b[2m[{} mana | {} size]\x1b[0m", view_term(&term), mana_dif, size_dif);
-        }
-        Ok(StatementInfo::Run {
+        StatementInfo::Run {
           done_term: term,
           used_mana: mana_dif,
           size_diff: size_dif,
           end_size: size_end as u128, // TODO: rename to done_size for consistency?
-        })
+        }
       }
       Statement::Reg { name, ownr, sign } => {
         let ownr = **ownr;
@@ -2125,12 +2131,13 @@ impl Runtime {
         }
         let name = *name;
         self.set_owner(name, ownr);
-        if !silent {
-          println!("[reg] #x{:0>30x} {}", ownr, name);
-        }
-        Ok(StatementInfo::Reg { name, ownr })
+        StatementInfo::Reg { name, ownr }
       }
+    };
+    if !silent {
+      println!("{}", res);
     }
+    Ok(res)
   }
 
   pub fn check_term(&self, term: &Term) -> bool {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -5053,7 +5053,7 @@ pub fn print_io_consts() {
 }
 
 // Serializes, deserializes and evaluates statements
-pub fn test_statements(statements: &[Statement]) {
+pub fn test_statements(statements: &[Statement], debug: bool) {
   let str_0 = view_statements(statements);
   let str_1 = view_statements(&crate::bits::deserialized_statements(&crate::bits::serialized_statements(&statements)).unwrap());
 
@@ -5063,7 +5063,7 @@ pub fn test_statements(statements: &[Statement]) {
 
   let mut rt = init_runtime(None);
   let init = Instant::now();
-  rt.run_statements(&statements, false, false);
+  rt.run_statements(&statements, false, debug);
   println!();
 
   println!("Stats");
@@ -5076,14 +5076,14 @@ pub fn test_statements(statements: &[Statement]) {
   println!("[time] {} ms", init.elapsed().as_millis());
 }
 
-pub fn test_statements_from_code(code: &str) {
+pub fn test_statements_from_code(code: &str, debug: bool) {
   let statments = read_statements(code);
   match statments {
-    Ok((.., statements)) => test_statements(&statements),
+    Ok((.., statements)) => test_statements(&statements, debug),
     Err(ParseErr { code, erro }) => println!("{}", erro),
   }
 }
 
-pub fn test_statements_from_file(file: &str) {
-  test_statements_from_code(&std::fs::read_to_string(file).expect("file not found"));
+pub fn test_statements_from_file(file: &str, debug: bool) {
+  test_statements_from_code(&std::fs::read_to_string(file).expect("file not found"), debug);
 }


### PR DESCRIPTION
This PR:

- adds flag to disable size limit / debug when testing code
- use `from_file_or_stdin` to get code in `test` and `serialize` cli commands
- extract code repetition from `run-remote` and `publish` to macro
- also adds `hex` flag on both
- impl `Display` for `StatementInfo`
- resolve lint errors
- handles code remainder in `parser_code`