### PR TITLE
add `get reg` cli command

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -8,7 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{hvm::{Term, self}, node};
 
-use super::{BlockInfo, FuncInfo, Hash, Name, Stats, HexStatement, CtrInfo};
+use super::{BlockInfo, FuncInfo, Hash, Name, Stats, HexStatement, CtrInfo, RegInfo};
 
 pub struct ApiClient {
   client: reqwest::Client,
@@ -133,5 +133,9 @@ impl ApiClient {
     } else {
       self.get::<Vec<node::Peer>>("/peers").await
     }
+  }
+
+  pub async fn get_reg_info(&self, name: &str) -> ApiResult<RegInfo> {
+    self.get::<RegInfo>(&format!("/reg/{}", name)).await
   }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -274,6 +274,12 @@ pub struct CtrInfo {
   pub arit: u64
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegInfo {
+  pub ownr: Name,
+  pub stmt: Vec<Name>
+}
+
 type RequestAnswer<T> = oneshot::Sender<T>;
 
 // Node Internal API
@@ -313,6 +319,10 @@ pub enum NodeRequest {
   GetConstructor {
     name: Name,
     tx: RequestAnswer<Option<CtrInfo>>,
+  },
+  GetReg {
+    name: Name,
+    tx: RequestAnswer<Option<RegInfo>>,
   },
   /// DEPRECATED
   TestCode {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,6 @@
 // TODO: flag enable logging statements results (disabled by default)
 // TODO: limit readback computational resources on aforementioned log and API calls
 
-// TODO: `kindelia get (reg|block) commands
-
 // TODO: flag to enable printing events (heartbeat) ?
 // TODO: some way to pretty-print events (heartbeat) ?
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -248,10 +248,10 @@ pub enum GetKind {
     #[clap(subcommand)]
     stat: GetFunKind,
   },
-  /// [NOT IMPLEMENTED] Get a registered namespace by name.
+  /// Get a registered namespace by name.
   Reg {
     /// The name of the namespace to get.
-    name: String, // ASK: use Name here too?
+    name: String,
     /// The stat of the namespace to get.
     #[clap(subcommand)]
     stat: GetRegKind,
@@ -625,7 +625,20 @@ pub async fn get_info(
       }
       GetFunKind::Slots => todo!(),
     },
-    GetKind::Reg { name: _, stat: _ } => todo!(),
+    GetKind::Reg { name, stat } => {
+      let reg_info = client.get_reg_info(&name).await?;
+      match stat {
+        GetRegKind::Owner => {
+          println!("{:x}", *(reg_info.ownr))
+        },
+        GetRegKind::List => {
+          for name in reg_info.stmt {
+            println!("{}", name)
+          }
+        }
+      }
+      Ok(())
+    },
     GetKind::Stats { stat_kind } => {
       let stats = client.get_stats().await?;
       match stat_kind {
@@ -702,7 +715,7 @@ pub fn publish_code(api_url: &str, stmts: Vec<Statement>) -> Result<(), String> 
   let f = |client: api_client::ApiClient, stmts| async move {
     client.publish_code(stmts).await
   };
-  let results = run_on_remote(&api_url, stmts, f)?;
+  let results = run_on_remote(api_url, stmts, f)?;
   for (i, result) in results.iter().enumerate() {
     print!("Transaction #{}: ", i);
     match result {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -2474,7 +2474,7 @@ impl Runtime {
     self.get_with(None, None, |heap| heap.read_file(name)).map(|func| (*func).clone())
   }
 
-  // TODO: refactor return to Option
+  // TODO: refactor to return Option
   pub fn get_arity(&self, name: &Name) -> u128 {
     if let Some(arity) = self.get_with(None, None, |heap| heap.read_arit(name)) {
       return arity;
@@ -2596,6 +2596,50 @@ impl Runtime {
     let dups = self.get_dups();
     self.get_heap_mut(self.draw).set_dups(dups + 1);
     return dups & 0x3FFFFFFF;
+  }
+
+  pub fn get_all_funs(&self) -> Vec<Name> {
+    let mut funcs: Vec<Name> = Vec::new();
+    self.reduce_with(&mut funcs, |acc, heap| {
+      let mut heap_funcs: Vec<Name> = 
+        heap.file.funcs
+          .keys()
+          .map(|f| Name::from_u128_unchecked(*f))
+          .collect();
+      acc.append(&mut heap_funcs);
+    });
+    funcs
+  }
+
+  pub fn get_all_ctr(&self) -> Vec<Name> {
+    let mut ctrs: Vec<Name> = Vec::new();
+    self.reduce_with(&mut ctrs, |acc, heap| {
+      let heap_funs: Vec<_> = 
+        heap.file.funcs
+          .keys()
+          .collect();
+      let mut heap_ctrs = 
+        heap.arit.arits
+          .keys()
+          .filter(|s| !heap_funs.contains(s))
+          .map(|c| Name::from_u128_unchecked(*c))
+          .collect();
+      acc.append(&mut heap_ctrs);
+    });
+    ctrs
+  }
+
+  pub fn get_all_ns(&self) -> Vec<Name> {
+    let mut ns: Vec<Name> = Vec::new();
+    self.reduce_with(&mut ns, |acc, heap| {
+      let mut heap_ns: Vec<Name> = 
+        heap.ownr.ownrs
+          .keys()
+          .map(|n| Name::from_u128_unchecked(*n))
+          .collect();
+      acc.append(&mut heap_ns);
+    });
+    ns
   }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,7 @@ use std::hash::BuildHasherDefault;
 use crate::NoHashHasher as NHH;
 use crate::print_with_timestamp;
 
-use crate::api::{self, CtrInfo};
+use crate::api::{self, CtrInfo, RegInfo};
 use crate::api::{NodeRequest, BlockInfo, FuncInfo};
 use crate::util::*;
 use crate::bits::*;
@@ -973,6 +973,29 @@ impl Node {
     }
   }
 
+  pub fn get_reg_info(&self, name: Name) -> Option<RegInfo> {
+    let ownr = self.runtime.get_owner(&name)?;
+    let ownr = Name::from_u128_unchecked(ownr);
+    let pred = |c: &Name| c.to_string().starts_with(&format!("{}.", name));
+    let ctrs: Vec<Name> = 
+      self.runtime.get_all_ctr()
+        .into_iter()
+        .filter(pred)
+        .collect();
+    let funs: Vec<Name> = 
+      self.runtime.get_all_funs()
+        .into_iter()
+        .filter(pred)
+        .collect();
+    let ns: Vec<Name> = 
+        self.runtime.get_all_ns()
+          .into_iter()
+          .filter(pred)
+          .collect();
+    let stmt = [ctrs, funs, ns].concat();
+    Some(RegInfo { ownr, stmt })
+  }
+
   pub fn handle_request(&mut self, request: NodeRequest) {
     // TODO: handle unwraps
     match request {
@@ -1050,6 +1073,10 @@ impl Node {
       },
       NodeRequest::GetConstructor { name, tx: answer } => {
         let info = self.get_ctr_info(&name);
+        answer.send(info).unwrap();
+      },
+      NodeRequest::GetReg { name, tx: answer } => {
+        let info = self.get_reg_info(name);
         answer.send(info).unwrap();
       },
       NodeRequest::TestCode { code, tx: answer } => {


### PR DESCRIPTION
For the `list` subcommand the node is searching through all `ctr`, `fun` and `reg` stored searching names that start with `<reg-name>.`. I did this way because we don't have any place that has the relation `Namespace -> Statement`. Should we have one?