### PR TITLE
Better persistence + GetIdx opcode

### DIFF
--- a/genesis.kdl
+++ b/genesis.kdl
@@ -71,6 +71,11 @@ fun (Tick) {
   (Tick) = @cont {TICK cont}
 }
 
+ctr {GIDX name cont}
+fun (GetIdx name) {
+  (GetIdx name) = @cont {GIDX name cont}
+}
+
 // TIME returns the current block timestamp
 ctr {TIME cont}
 fun (Time) {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -2134,7 +2134,7 @@ impl Runtime {
     if included {
       self.save_state_metadata().expect("Error saving state metadata.");
       let path = &self.get_dir_path();
-      let _ = &self.heap[self.curr as usize].serialize(path, true).expect("Error saving buffers.");
+      &self.heap[self.curr as usize].serialize(path, true).expect("Error saving buffers.");
       if let Some(deleted) = deleted {
         if let Some(absorber) = absorber {
           self.absorb_heap(absorber, deleted, false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod hvm;
 mod net;
 mod node;
 mod util;
+mod persistence;
 
 #[cfg(feature = "events")]
 mod events;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,159 @@
+use std::io::{Read, Write, Result as IoResult, Error, ErrorKind};
+use std::hash::{Hash, BuildHasher};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::ops::Deref;
+use crate::hvm::{CompFunc, Func, compile_func};
+use crate::bits::ProtoSerialize;
+
+pub trait DiskSer
+where
+  Self: Sized,
+{
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize>;
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<Self>>;
+}
+
+impl DiskSer for u8 {
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    sink.write(&self.to_le_bytes())
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<u8>> {
+    let mut buf = [0; 1];
+    let bytes_read = source.read(&mut buf)?;
+    match bytes_read {
+      0 => { Ok(None) }
+      _ => { Ok(Some(u8::from_le_bytes(buf))) }
+    }
+  }
+}
+impl DiskSer for i128 {
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    sink.write(&self.to_le_bytes())
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<i128>> {
+    const BYTES : usize = (i128::BITS / 8) as usize;
+    const AT_MOST : usize = BYTES-1;
+    let mut buf = [0; BYTES];
+    let bytes_read = source.read(&mut buf)?;
+    match bytes_read {
+      0 => { Ok(None) }
+      1..=AT_MOST => { Err(Error::from(ErrorKind::UnexpectedEof)) }
+      _ => { Ok(Some(i128::from_le_bytes(buf))) }
+    }
+  }
+}
+
+impl DiskSer for u128 {
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    sink.write(&self.to_le_bytes())
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<u128>> {
+    const BYTES : usize = (u128::BITS / 8) as usize;
+    const AT_MOST : usize = BYTES-1;
+    let mut buf = [0; BYTES];
+    let bytes_read = source.read(&mut buf)?;
+    match bytes_read {
+      0 => { Ok(None) }
+      1..=AT_MOST => { Err(Error::from(ErrorKind::UnexpectedEof)) }
+      _ => { Ok(Some(u128::from_le_bytes(buf))) }
+    }
+  }
+}
+
+// we assume that every map will be stored in a whole file.
+// because of that, it will consume all of the file while reading it.
+impl<K, V, H> DiskSer for HashMap<K, V, H>
+where
+  K: DiskSer + Eq + Hash,
+  V: DiskSer,
+  H: BuildHasher + Default,
+{
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    let mut total_written = 0;
+    for (k, v) in self {
+      let key_size = k.disk_serialize(sink)?;
+      let val_size = v.disk_serialize(sink)?;
+      total_written += key_size + val_size;
+    }
+    sink.flush()?;
+    Ok(total_written)
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<Self>> {
+    let mut slf = HashMap::with_hasher(H::default());
+    while let Some(key) = K::disk_deserialize(source)? {
+      let val = V::disk_deserialize(source)?;
+      if let Some(val) = val {
+        slf.insert(key, val);
+      }
+      else {
+        return Err(Error::from(ErrorKind::UnexpectedEof));
+      }     
+    }
+    Ok(Some(slf))
+  }
+}
+
+impl <K> DiskSer for Vec<K>
+where
+  K: DiskSer,
+{
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    let mut total_written = 0;
+    for elem in self {
+      let elem_size = elem.disk_serialize(sink)?;
+      total_written += elem_size;
+    }
+    Ok(total_written)      
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<Self>> {
+    let mut res = Vec::new();
+    while let Some(elem) = K::disk_deserialize(source)? {
+        res.push(elem);
+    }
+    Ok(Some(res))
+  }
+}
+
+impl<T> DiskSer for Arc<T>
+where
+  T: DiskSer,
+{
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize> {
+    let t = Arc::deref(self);
+    t.disk_serialize(sink)
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<Self>> {
+    let t = T::disk_deserialize(source)?;
+    Ok(t.map(Arc::new))
+  }
+}
+
+impl DiskSer for CompFunc {
+  fn disk_serialize<W: Write>(&self, sink: &mut W) -> IoResult<usize>{
+    let func_buff = self.func.proto_serialized().to_bytes();
+    let size = func_buff.len() as u128;
+    let written1 = size.disk_serialize(sink)?;
+    let written2 = func_buff.disk_serialize(sink)?;
+    Ok(written1 + written2)
+  }
+  fn disk_deserialize<R: Read>(source: &mut R) -> IoResult<Option<Self>> {
+    // let compfunc = CompFunc {};
+    if let Some(len) = u128::disk_deserialize(source)? {
+      let len = len as usize;
+      let mut buf = vec![0; len];
+      let read_bytes = source.read(&mut buf)?;
+      if read_bytes != len {
+        return Err(Error::from(ErrorKind::UnexpectedEof));
+      }
+      let func = &Func::proto_deserialized(&bit_vec::BitVec::from_bytes(&buf))
+        .ok_or_else(|| Error::from(ErrorKind::InvalidData))?; // invalid data? which error is better?
+      let func = compile_func(func, false)
+        .ok_or_else(|| Error::from(ErrorKind::InvalidData))?;
+      Ok(Some(func))
+    }
+    else {
+      Ok(None)
+    }
+  }
+}

--- a/src/test/hvm.rs
+++ b/src/test/hvm.rs
@@ -4,13 +4,13 @@ use crate::{
   common::Name,
   hvm::{
     self, init_map, init_runtime, read_statements, readback_term, show_term,
-    view_statements, view_term, Rollback, Runtime, StatementInfo, Term, U120,
+    view_statements, view_term, Rollback, Runtime, StatementInfo, Term, U120, Heap
   },
   test::{
     strategies::{func, heap, name, op2, statement, term},
     util::{
       self, advance, rollback, rollback_path, rollback_simple, run_term_and,
-      run_term_from_code_and, temp_dir, test_heap_checksum,
+      run_term_from_code_and, temp_dir, temp_file, test_heap_checksum,
       view_rollback_ticks, RuntimeStateTest, TempPath,
     },
   },
@@ -456,12 +456,15 @@ proptest! {
   #[test]
   #[ignore = "slow"]
   fn serialize_deserialize_heap(heap in heap()) {
-    let mut h1 = heap;
-    let s1 = format!("{:?}", h1);
-    let a = h1.serialize();
-    h1.deserialize(&a);
-    let s2 = format!("{:?}", h1);
-    assert_eq!(s1, s2);
+    let h1 = heap;
+    let path = temp_dir();
+    h1.serialize(&path.path, false).unwrap();
+    if let Ok(h2) = Heap::deserialize(h1.uuid, &path.path) {
+        assert_eq!(h1, h2);
+    }
+    else {
+        panic!("Could not deserialize")
+    }
   }
 }
 

--- a/src/test/strategies.rs
+++ b/src/test/strategies.rs
@@ -6,7 +6,7 @@ use crate::{
   hvm::{
     init_map, Arits, CompFunc, CompRule, Func, Funcs,
     Heap, Map, Nodes, Oper, Ownrs, Rollback, Rule, Runtime,
-    SerializedHeap, Statement, Store, Term, Var, U120,
+    SerializedHeap, Statement, Store, Term, Var, U120, Indxs,
   },
   net::Address,
   node::{hash_bytes, Block, Body, Message, Peer, Transaction},
@@ -155,6 +155,9 @@ pub fn arits() -> impl Strategy<Value = Arits> {
 pub fn ownrs() -> impl Strategy<Value = Ownrs> {
   map(any::<u128>()).prop_map(|m| Ownrs { ownrs: m })
 }
+pub fn indxs() -> impl Strategy<Value = Indxs> {
+  map(any::<u128>()).prop_map(|m| Indxs { indxs: m })
+}
 
 pub fn var() -> impl Strategy<Value = Var> {
   (name(), any::<u128>(), option::of(any::<u128>()), any::<bool>())
@@ -199,6 +202,7 @@ pub fn heap() -> impl Strategy<Value = Heap> {
     arits(),
     ownrs(),
     funcs(),
+    indxs(),
   )
     .prop_map(
       |(
@@ -210,11 +214,13 @@ pub fn heap() -> impl Strategy<Value = Heap> {
         arit,
         ownr,
         file,
+        indx,
       )| Heap {
         mcap,
         disk,
         arit,
         ownr,
+        indx,
         file: Funcs { funcs: init_map() }, // TODO, fix?
         uuid,
         memo,

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -252,7 +252,7 @@ where
     args: [term.clone()].to_vec(),
   };
   let stmt = Statement::Run { expr: term, sign: None };
-  let result = rt.run_statement(&stmt, false, true).unwrap();
+  let result = rt.run_statement(&stmt, false, true, None).unwrap();
 
   if let StatementInfo::Run { done_term, .. } = result {
     action(&done_term)

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -331,6 +331,7 @@ impl Drop for TempPath {
 pub fn temp_dir() -> TempPath {
   let path =
     std::env::temp_dir().join(format!("kindelia.{:x}", fastrand::u128(..)));
+  std::fs::create_dir_all(&path).unwrap();
   let temp_dir = TempPath { path };
   temp_dir
 }


### PR DESCRIPTION
Adding trait `DiskSer` to serialize types to disk. Using this trait, we can serialize arbitrary hashmaps, vectors and whole types. This will remove the need to use only `u128 -> u128` hashmaps. Will also enable to use `Name` newtype easily in the maps.

Also adds a new `Indx` struct to Heap, that represents a map of `statement 'name' -> statement index`.