### PR TITLE
feat(cli): impl shell completion command (master)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,32 +428,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
+dependencies = [
+ "clap 4.0.18",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -464,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1401,7 +1408,8 @@ dependencies = [
  "assert_cmd",
  "bit-vec",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.18",
+ "clap_complete",
  "criterion",
  "derive_builder",
  "dirs",
@@ -2771,12 +2779,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 sha3 = "0.9.1"
 
 # CLI / configuration
-clap = { version = "3.1.3", features = ["derive"] }
+clap = { version = "4.0.18", features = ["derive"] }
+clap_complete = "4.0.3"
 toml = "0.5.9"
 
 # Datastructures


### PR DESCRIPTION
Addresses #158.

Implements 'completion' command to output shell completions for bash, powershell, fish, zsh, etc, as supported by clap_complete crate.

Introduces a dependency on clap_complete and update clap dep to 4.0.18.

```
$ kindelia completion --help
Generate auto-completion for a shell

Usage: kindelia completion <SHELL>

Arguments:
  <SHELL>  The shell to generate completion for [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -h, --help  Print help information
```

Example of usage in bash.

```
$ kindelia completion bash > /tmp/completions.bash

$ source /tmp/completions.bash 

$ kindelia <tab>
--api        --config     -h           init         publish      sign         util         
-c           deserialize  help         node         run-remote   test         -V           
completion   get          --help       post         serialize    unserialize  --version 

$ kindelia publish <tab>
-e         --encoded  <FILE>     -h         --help     
```

I kept this impl as simple as possible.  Future improvements could include:
* option to generate completions for all known shells and write each to a file.
* execute within build.rs to auto-generate completion files at compile time.