### PR TITLE
feat(cli): impl shell completion command (dev)

### DIFF
--- a/kindelia/Cargo.toml
+++ b/kindelia/Cargo.toml
@@ -32,7 +32,8 @@ hex = "0.4"
 derive_builder = "0.11.2"
 
 # CLI / configuration
-clap = { version = "3.1.3", features = ["derive"] }
+clap = { version = "4.0.18", features = ["derive"] }
+clap_complete = "4.0.3"
 toml = "0.5.9"
 
 # Datastructures

--- a/kindelia/src/cli.rs
+++ b/kindelia/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 use kindelia_core::common::Name;
 
@@ -163,7 +164,7 @@ pub enum CliCommand {
   /// Generate auto-completion for a shell.
   Completion {
     /// The shell to generate completion for.
-    shell: String,
+    shell: Shell,
   },
   Util {
     /// Which command run.

--- a/kindelia/src/files.rs
+++ b/kindelia/src/files.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 /// Represents input from a file or stdin.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FileInput {
   Stdin,
   Path { path: PathBuf },


### PR DESCRIPTION
Addresses #158.

obsoletes #218.  (this PR applies to dev branch.  #218 applies to master)

Implements 'completion' command to output shell completions for bash, powershell, fish, zsh, etc, as supported by clap_complete crate.

Introduces a dependency on clap_complete and update clap dep to 4.0.18.

```
$ kindelia completion --help
Generate auto-completion for a shell

Usage: kindelia completion <SHELL>

Arguments:
  <SHELL>  The shell to generate completion for [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -h, --help  Print help information
```

Example of usage in bash.

```
$ kindelia completion bash > /tmp/completions.bash

$ source /tmp/completions.bash 

$ kindelia <tab>
--api        --config     -h           init         publish      sign         util         
-c           deserialize  help         node         run-remote   test         -V           
completion   get          --help       post         serialize    unserialize  --version 

$ kindelia publish <tab>
-e         --encoded  <FILE>     -h         --help     
```

I kept this impl as simple as possible.  Future improvements could include:
* option to generate completions for all known shells and write each to a file.
* execute within build.rs to auto-generate completion files at compile time.
