### PR TITLE
feat(cli): publish to multiple nodes

### DIFF
--- a/kindelia/src/main.rs
+++ b/kindelia/src/main.rs
@@ -28,12 +28,12 @@ use kindelia_core::events;
 use kindelia_core::hvm::{
   self, view_statement, view_statement_header, Statement,
 };
-use kindelia_core::parser;
 use kindelia_core::net;
-use kindelia_core::net::ProtoComm;
+use kindelia_core::net::{Address, ProtoComm};
 use kindelia_core::node::{
   spawn_miner, Node, Transaction, TransactionError, MAX_TRANSACTION_SIZE,
 };
+use kindelia_core::parser;
 use kindelia_core::persistence::{
   get_ordered_blocks_path, SimpleFileStorage, BLOCKS_DIR,
 };
@@ -575,18 +575,74 @@ pub fn publish_code(
   api_url: &str,
   stmts: Vec<Statement>,
 ) -> Result<(), String> {
-  let f =
-    |client: ApiClient, stmts| async move { client.publish_code(stmts).await };
-  let results = run_on_remote(api_url, stmts, f)?;
-  for (i, result) in results.iter().enumerate() {
-    print!("Transaction #{}: ", i);
-    match result {
-      Ok(_) => println!("PUBLISHED (tx added to mempool)"),
-      Err(_) => {
-        println!("NOT PUBLISHED (tx is probably already on mempool)")
-      }
-    }
+  // setup tokio runtime and unordered joinset (tasks).
+  let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+  let mut tasks = tokio::task::JoinSet::new();
+
+  let client = ApiClient::new(api_url, None).map_err(|e| e.to_string())?;
+
+  // obtain list of active peers known to "our" node.
+  let prom = async move { client.get_peers::<NC>(false).await };
+  let peers = runtime.block_on(prom)?;
+
+  let stmts_hex: Vec<HexStatement> =
+    stmts.into_iter().map(|s| s.into()).collect();
+
+  for peer in peers.into_iter() {
+    // these are move'd into the spawned task, so they must be
+    // created for each iteration.
+    let client = ApiClient::new(api_url, None).map_err(|e| e.to_string())?;
+    let stmts_hex = stmts_hex.clone();
+
+    // spawn a new task for contacting each peer.  Because it is
+    // spawn'd, the task should begin executing immediately.
+    tasks.spawn_on(
+      async move {
+        let peer_url = match peer.address {
+          Address::IPv4 { val0, val1, val2, val3, port: _ } => {
+            // strips the port, so port 80 is assumed/default.
+            // note:  we just assume/guess that this host has
+            //        a webservice running on port 80. (gross)
+            //        this is a fragile and temporary hack until
+            //        code is relayed properly by p2p nodes.
+            format!("http://{}.{}.{}.{}", val0, val1, val2, val3)
+          }
+        };
+
+        let results = match client.publish_code(stmts_hex.clone()).await {
+          Ok(r) => r,
+          Err(e) => {
+            println!("NOT PUBLISHED to {}. ({})", peer_url, e);
+            return Err(e);
+          }
+        };
+        for (i, result) in results.iter().enumerate() {
+          print!("Transaction #{}: ", i);
+          match result {
+            Ok(_) => {
+              println!("PUBLISHED to {} (tx added to mempool)", peer_url)
+            }
+            Err(_) => {
+              println!(
+                "NOT PUBLISHED to {} (tx is probably already on mempool)",
+                peer_url,
+              )
+            }
+          }
+        }
+        Ok(())
+      },
+      runtime.handle(),
+    );
   }
+  // wait for all tasks to complete.
+  runtime.block_on(join_all(tasks))
+}
+
+async fn join_all(
+  mut tasks: tokio::task::JoinSet<Result<(), String>>,
+) -> Result<(), String> {
+  while let Some(_res) = tasks.join_next().await {}
   Ok(())
 }
 

--- a/kindelia_core/src/api.rs
+++ b/kindelia_core/src/api.rs
@@ -108,7 +108,7 @@ impl From<Hash> for String {
 
 /// Decorator for Statement that serializes it as hexadecimal string of the
 /// protocol's serialization format.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HexStatement(hvm::Statement);
 
 impl std::ops::Deref for HexStatement {

--- a/kindelia_core/src/hvm.rs
+++ b/kindelia_core/src/hvm.rs
@@ -395,7 +395,7 @@ pub struct Store {
 }
 
 /// A global statement that alters the state of the blockchain
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Statement {
   Fun { name: Name, args: Vec<Name>, func: Func, init: Option<Term>, sign: Option<crypto::Signature> },
   Ctr { name: Name, args: Vec<Name>, sign: Option<crypto::Signature> },


### PR DESCRIPTION
Addresses #173.

modifies the publish command to first query "our" node for its peers and then concurrently publish to each peer.

This is just a temporary feature until the p2p layer properly transmits code between nodes.

notes:
* This is kind of a draft, looking for feedback.  but if you feel its ok to merge, go for it.
* I didn't bother with creating a flag/mode to publish only to "our" node (original behavior) because this is just a temporary thing, and I didn't want to put too much time/complexity into it.  But if its important, let me know.
* seems to work as intended, but I haven't yet tested what happens when a node is slow or unavailable.
* I'm not a rust thread/tokio/async wizard, so I believe it is parallel+concurrent, but there could be some gotcha there, eg tokio decides to run all tasks on the same thread for whatever black box reason.